### PR TITLE
Add Rust hobby OS scaffold with simple shell and VirtualBox workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,7 @@ While this is an 8-bit processor, it includes features necessary for a minimal L
 
 Note: This will be a severely limited Linux implementation, more like a microkernel.
 # micro-processor
+
+## Hobby OS Starter
+
+A new starter operating system scaffold is available in `hobby_os/` with a Rust kernel, simple shell, and VirtualBox boot flow. See `hobby_os/README.md` for usage.

--- a/hobby_os/Makefile
+++ b/hobby_os/Makefile
@@ -3,20 +3,24 @@ BUILD_DIR := build
 PROGRAMS_DIR := programs
 OUT_DIR := out
 IMAGE := $(KERNEL_DIR)/target/x86_64-unknown-none/debug/bootimage-aruvix_hobby_os.bin
+PROGRAM_BUNDLE := $(OUT_DIR)/program_bundle
 
-.PHONY: help image run run-headless virtualbox programs test-terminal test-programs test clean
+.PHONY: help image run run-headless virtualbox vdi programs bundle-programs test-terminal test-programs test readiness clean
 
 help:
 	@echo "Targets:"
-	@echo "  make image         - build bootable HobbyOS image"
-	@echo "  make run           - launch QEMU with graphics + serial"
-	@echo "  make run-headless  - launch QEMU in terminal-only mode"
-	@echo "  make virtualbox    - print VDI conversion command"
-	@echo "  make programs      - compile sample C/ASM host-side utilities"
-	@echo "  make test-terminal - run serial shell smoke test in QEMU"
-	@echo "  make test-programs - validate sample C/ASM programs compile"
-	@echo "  make test          - run all tests"
-	@echo "  make clean         - remove artifacts"
+	@echo "  make image           - build bootable HobbyOS image"
+	@echo "  make run             - launch QEMU with graphics + serial"
+	@echo "  make run-headless    - launch QEMU in terminal-only mode"
+	@echo "  make virtualbox      - print VDI conversion command"
+	@echo "  make vdi             - build image and create hobby_os.vdi via VBoxManage"
+	@echo "  make programs        - compile sample C/ASM host-side utilities"
+	@echo "  make bundle-programs - package sample programs into out/program_bundle/"
+	@echo "  make test-terminal   - run serial shell smoke test in QEMU"
+	@echo "  make test-programs   - validate sample C/ASM programs compile"
+	@echo "  make test            - run all available tests"
+	@echo "  make readiness       - print readiness notes for DOS-like goals"
+	@echo "  make clean           - remove artifacts"
 
 image:
 	$(MAKE) -C $(BUILD_DIR) image
@@ -30,12 +34,23 @@ run-headless: image
 virtualbox: image
 	@echo "VBoxManage convertfromraw $(IMAGE) hobby_os.vdi --format VDI"
 
+vdi: image
+	@bash scripts/create_vdi.sh "$(IMAGE)" hobby_os.vdi
+
 programs:
 	@mkdir -p $(OUT_DIR)
 	@gcc $(PROGRAMS_DIR)/c/hello_util.c -o $(OUT_DIR)/hello_util
 	@gcc $(PROGRAMS_DIR)/c/sum_util.c -o $(OUT_DIR)/sum_util
 	@as $(PROGRAMS_DIR)/asm/noop_util.s -o $(OUT_DIR)/noop_util.o
 	@echo "Built sample programs in $(OUT_DIR)/"
+
+bundle-programs: programs
+	@mkdir -p $(PROGRAM_BUNDLE)
+	@cp -f $(OUT_DIR)/hello_util $(PROGRAM_BUNDLE)/
+	@cp -f $(OUT_DIR)/sum_util $(PROGRAM_BUNDLE)/
+	@cp -f $(OUT_DIR)/noop_util.o $(PROGRAM_BUNDLE)/
+	@printf "hello_util\nsum_util\nnoop_util.o\n" > $(PROGRAM_BUNDLE)/manifest.txt
+	@echo "Program bundle created at $(PROGRAM_BUNDLE)/"
 
 test-terminal: image
 	@python3 scripts/test_terminal.py
@@ -49,6 +64,9 @@ test-programs:
 	@echo "Program build tests passed"
 
 test: test-programs test-terminal
+
+readiness:
+	@cat docs/readiness.md
 
 clean:
 	$(MAKE) -C $(BUILD_DIR) clean

--- a/hobby_os/Makefile
+++ b/hobby_os/Makefile
@@ -1,0 +1,55 @@
+KERNEL_DIR := kernel
+BUILD_DIR := build
+PROGRAMS_DIR := programs
+OUT_DIR := out
+IMAGE := $(KERNEL_DIR)/target/x86_64-unknown-none/debug/bootimage-aruvix_hobby_os.bin
+
+.PHONY: help image run run-headless virtualbox programs test-terminal test-programs test clean
+
+help:
+	@echo "Targets:"
+	@echo "  make image         - build bootable HobbyOS image"
+	@echo "  make run           - launch QEMU with graphics + serial"
+	@echo "  make run-headless  - launch QEMU in terminal-only mode"
+	@echo "  make virtualbox    - print VDI conversion command"
+	@echo "  make programs      - compile sample C/ASM host-side utilities"
+	@echo "  make test-terminal - run serial shell smoke test in QEMU"
+	@echo "  make test-programs - validate sample C/ASM programs compile"
+	@echo "  make test          - run all tests"
+	@echo "  make clean         - remove artifacts"
+
+image:
+	$(MAKE) -C $(BUILD_DIR) image
+
+run: image
+	qemu-system-x86_64 -drive format=raw,file=$(IMAGE) -serial stdio
+
+run-headless: image
+	qemu-system-x86_64 -drive format=raw,file=$(IMAGE) -nographic -serial stdio -monitor none -display none
+
+virtualbox: image
+	@echo "VBoxManage convertfromraw $(IMAGE) hobby_os.vdi --format VDI"
+
+programs:
+	@mkdir -p $(OUT_DIR)
+	@gcc $(PROGRAMS_DIR)/c/hello_util.c -o $(OUT_DIR)/hello_util
+	@gcc $(PROGRAMS_DIR)/c/sum_util.c -o $(OUT_DIR)/sum_util
+	@as $(PROGRAMS_DIR)/asm/noop_util.s -o $(OUT_DIR)/noop_util.o
+	@echo "Built sample programs in $(OUT_DIR)/"
+
+test-terminal: image
+	@python3 scripts/test_terminal.py
+
+test-programs:
+	@mkdir -p $(OUT_DIR)
+	@gcc -Wall -Wextra -Werror $(PROGRAMS_DIR)/c/hello_util.c -o $(OUT_DIR)/hello_util.test
+	@gcc -Wall -Wextra -Werror $(PROGRAMS_DIR)/c/sum_util.c -o $(OUT_DIR)/sum_util.test
+	@as $(PROGRAMS_DIR)/asm/noop_util.s -o $(OUT_DIR)/noop_util.test.o
+	@./$(OUT_DIR)/sum_util.test 20 22 | grep -q '^42$$'
+	@echo "Program build tests passed"
+
+test: test-programs test-terminal
+
+clean:
+	$(MAKE) -C $(BUILD_DIR) clean
+	@rm -rf $(OUT_DIR)

--- a/hobby_os/README.md
+++ b/hobby_os/README.md
@@ -1,0 +1,71 @@
+# Hobby OS (VirtualBox-friendly, Rust kernel)
+
+This folder is a self-contained starter operating system project with a **simple shell**, a **utility registry**, and a build path that can produce a bootable image.
+
+## Folder structure
+
+```
+hobby_os/
+├── build/
+│   └── Makefile                 # Build/run helper commands
+├── docs/
+│   └── roadmap.md               # Suggested evolution plan
+├── kernel/
+│   ├── .cargo/config.toml       # Bare-metal target
+│   ├── Cargo.toml               # Kernel crate dependencies
+│   ├── rust-toolchain.toml      # Toolchain components
+│   └── src/
+│       ├── main.rs              # Kernel entrypoint + panic handler
+│       ├── shell.rs             # Simple shell + command parsing
+│       ├── keyboard.rs          # PS/2 scancode input
+│       └── vga.rs               # VGA text output
+└── user_utils/
+    └── src/
+        ├── echo.c               # Example C utility skeleton
+        └── sum.c                # Example C utility skeleton
+```
+
+## What this already does
+
+- Boots to VGA text mode.
+- Prints a shell prompt.
+- Accepts keyboard input.
+- Supports:
+  - `help`
+  - `ls` (lists registered utilities)
+  - `run <utility> [args]`
+  - `clear`
+- Includes registered demo utilities:
+  - `echo`
+  - `sum`
+  - `about`
+
+## Build and run
+
+```bash
+cd hobby_os/build
+make image
+make run
+```
+
+## Run in VirtualBox
+
+1. Build image (`make image`).
+2. Convert raw image to VDI:
+   ```bash
+   VBoxManage convertfromraw ../kernel/target/x86_64-unknown-none/debug/bootimage-aruvix_hobby_os.bin hobby_os.vdi --format VDI
+   ```
+3. Create VM (Other/Unknown OS).
+4. Attach `hobby_os.vdi` as primary disk.
+5. Boot VM.
+
+## Next milestone for C utilities
+
+Right now utility execution is in-kernel Rust function dispatch. The next step is:
+
+1. Define a tiny utility ABI (`int main(int argc, char** argv)` style).
+2. Compile C utilities into flat binaries.
+3. Add a tiny in-memory filesystem or ROM loader.
+4. Extend `run` to load binary utility image and jump to entrypoint in user mode.
+
+This gives the full cycle you asked for: list utilities, execute utilities, and keep extending toward a small but real OS.

--- a/hobby_os/README.md
+++ b/hobby_os/README.md
@@ -10,7 +10,8 @@ hobby_os/
 │   └── Makefile                 # Low-level image build helper
 ├── Makefile                     # Top-level build/run/test orchestration
 ├── docs/
-│   └── roadmap.md               # Suggested evolution plan
+│   ├── roadmap.md               # Suggested evolution plan
+│   └── readiness.md             # Gap analysis vs DOS-like goals
 ├── kernel/
 │   ├── .cargo/config.toml       # Bare-metal target
 │   ├── Cargo.toml               # Kernel crate dependencies
@@ -24,6 +25,7 @@ hobby_os/
 │   ├── c/                        # Sample host-side C utilities
 │   └── asm/                      # Sample host-side ASM utility
 ├── scripts/
+│   ├── create_vdi.sh            # VirtualBox VDI conversion helper
 │   └── test_terminal.py          # QEMU serial smoke test runner
 ├── tests/
 │   └── test_cases.md             # Documented test scenarios
@@ -54,6 +56,7 @@ hobby_os/
 cd hobby_os
 make image
 make run
+make bundle-programs
 ```
 
 
@@ -71,11 +74,25 @@ make test            # full test suite
 1. Build image (`make image`).
 2. Convert raw image to VDI:
    ```bash
+   make vdi
+   # or manually:
    VBoxManage convertfromraw ../kernel/target/x86_64-unknown-none/debug/bootimage-aruvix_hobby_os.bin hobby_os.vdi --format VDI
    ```
 3. Create VM (Other/Unknown OS).
 4. Attach `hobby_os.vdi` as primary disk.
 5. Boot VM.
+
+## Readiness (important)
+
+This repo currently provides a DOS-like shell experience, but **external program execution is not complete yet**.
+
+Run:
+
+```bash
+make readiness
+```
+
+for an exact requirement-by-requirement status and missing pieces.
 
 ## Next milestone for C utilities
 

--- a/hobby_os/README.md
+++ b/hobby_os/README.md
@@ -7,7 +7,8 @@ This folder is a self-contained starter operating system project with a **simple
 ```
 hobby_os/
 ├── build/
-│   └── Makefile                 # Build/run helper commands
+│   └── Makefile                 # Low-level image build helper
+├── Makefile                     # Top-level build/run/test orchestration
 ├── docs/
 │   └── roadmap.md               # Suggested evolution plan
 ├── kernel/
@@ -19,6 +20,13 @@ hobby_os/
 │       ├── shell.rs             # Simple shell + command parsing
 │       ├── keyboard.rs          # PS/2 scancode input
 │       └── vga.rs               # VGA text output
+├── programs/
+│   ├── c/                        # Sample host-side C utilities
+│   └── asm/                      # Sample host-side ASM utility
+├── scripts/
+│   └── test_terminal.py          # QEMU serial smoke test runner
+├── tests/
+│   └── test_cases.md             # Documented test scenarios
 └── user_utils/
     └── src/
         ├── echo.c               # Example C utility skeleton
@@ -43,9 +51,19 @@ hobby_os/
 ## Build and run
 
 ```bash
-cd hobby_os/build
+cd hobby_os
 make image
 make run
+```
+
+
+## Test workflow
+
+```bash
+cd hobby_os
+make test-programs   # checks C/ASM sample utilities
+make test-terminal   # boots QEMU and validates shell behavior
+make test            # full test suite
 ```
 
 ## Run in VirtualBox

--- a/hobby_os/docs/readiness.md
+++ b/hobby_os/docs/readiness.md
@@ -1,0 +1,45 @@
+# DOS-like Readiness Review (Current State)
+
+## Short answer
+Not yet fully ready for external program loading/execution. The current shell executes **built-in Rust functions**, not packaged user binaries.
+
+## Requirement-by-requirement status
+
+1. **Build OS and open in VirtualBox**
+   - Status: **Partially ready**
+   - We can build a raw boot image and convert it to VDI using `make vdi` (requires `VBoxManage`).
+
+2. **DOS-like operating system**
+   - Status: **Early prototype**
+   - Command prompt and basic command dispatch exist.
+
+3. **CLI when OS starts**
+   - Status: **Ready**
+   - Boot shows prompt and accepts keyboard/serial input.
+
+4. **Ship simple programs**
+   - Status: **Partially ready**
+   - Host-side samples are built and bundled (`make bundle-programs`), but the kernel does not load this bundle yet.
+
+5. **Type command and execute program**
+   - Status: **Partially ready**
+   - Works for built-ins (`run echo`, `run sum`, `run about`) only.
+
+6. **Program stdin/stdout**
+   - Status: **Not ready for external user programs**
+   - stdin/stdout works in shell path and built-ins via keyboard/serial + VGA/serial mirror, but no process/ABI boundary exists yet.
+
+## What is missing for true DOS-like external apps
+
+- Utility binary format for your CPU (RISC ISA target).
+- Loader (read program bytes from storage and map into memory).
+- Process model (register context, stack, exit path).
+- Syscall ABI (at minimum: read/write/exit).
+- Filesystem/disk layout for shipping multiple utility binaries.
+
+## Packaging focus (next practical step)
+
+1. Choose executable format (flat binary first, then ELF).
+2. Add a read-only bundled "program volume" with manifest.
+3. Add `run <name>` path to resolve name -> load bytes -> jump to entry.
+4. Add syscall gateway for stdin/stdout.

--- a/hobby_os/docs/roadmap.md
+++ b/hobby_os/docs/roadmap.md
@@ -1,0 +1,22 @@
+# Hobby OS Roadmap
+
+## Phase 1 (done in this scaffold)
+- Bootable Rust kernel.
+- VGA console output.
+- PS/2 keyboard input.
+- Command shell with utility registry.
+
+## Phase 2
+- Add timer interrupt and clock ticks.
+- Add command history + line editing.
+- Add static RAM-backed filesystem.
+
+## Phase 3
+- Add user-mode process model.
+- Define syscall table (`write`, `exit`, `open`, `read`).
+- Run C-compiled utility binaries from the shell.
+
+## Phase 4
+- Add ELF loader.
+- Add tiny libc shim for utilities.
+- Add package script to bundle utilities into disk image.

--- a/hobby_os/kernel/.cargo/config.toml
+++ b/hobby_os/kernel/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "x86_64-unknown-none"
+
+[target.'cfg(target_os = "none")']
+runner = "bootimage runner"

--- a/hobby_os/kernel/Cargo.toml
+++ b/hobby_os/kernel/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "aruvix_hobby_os"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bootloader = { version = "0.11", features = ["binary"] }
+lazy_static = { version = "1.4", features = ["spin_no_std"] }
+spin = "0.9"
+volatile = "0.4"
+x86_64 = "0.14"
+heapless = { version = "0.8", default-features = false }
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/hobby_os/kernel/rust-toolchain.toml
+++ b/hobby_os/kernel/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rust-src", "llvm-tools-preview"]

--- a/hobby_os/kernel/src/keyboard.rs
+++ b/hobby_os/kernel/src/keyboard.rs
@@ -9,7 +9,16 @@ pub fn read_char_blocking() -> char {
     }
 }
 
-fn try_read_char() -> Option<char> {
+pub fn try_read_char() -> Option<char> {
+    let data_ready = unsafe {
+        let mut status_port = Port::<u8>::new(0x64);
+        status_port.read() & 0x01 != 0
+    };
+
+    if !data_ready {
+        return None;
+    }
+
     let scancode = unsafe {
         let mut data_port = Port::<u8>::new(0x60);
         data_port.read()

--- a/hobby_os/kernel/src/keyboard.rs
+++ b/hobby_os/kernel/src/keyboard.rs
@@ -1,0 +1,77 @@
+use x86_64::instructions::port::Port;
+
+pub fn read_char_blocking() -> char {
+    loop {
+        if let Some(ch) = try_read_char() {
+            return ch;
+        }
+        x86_64::instructions::hlt();
+    }
+}
+
+fn try_read_char() -> Option<char> {
+    let scancode = unsafe {
+        let mut data_port = Port::<u8>::new(0x60);
+        data_port.read()
+    };
+
+    if scancode & 0x80 != 0 {
+        return None;
+    }
+
+    map_scancode(scancode)
+}
+
+fn map_scancode(scancode: u8) -> Option<char> {
+    let c = match scancode {
+        0x02 => '1',
+        0x03 => '2',
+        0x04 => '3',
+        0x05 => '4',
+        0x06 => '5',
+        0x07 => '6',
+        0x08 => '7',
+        0x09 => '8',
+        0x0a => '9',
+        0x0b => '0',
+        0x10 => 'q',
+        0x11 => 'w',
+        0x12 => 'e',
+        0x13 => 'r',
+        0x14 => 't',
+        0x15 => 'y',
+        0x16 => 'u',
+        0x17 => 'i',
+        0x18 => 'o',
+        0x19 => 'p',
+        0x1e => 'a',
+        0x1f => 's',
+        0x20 => 'd',
+        0x21 => 'f',
+        0x22 => 'g',
+        0x23 => 'h',
+        0x24 => 'j',
+        0x25 => 'k',
+        0x26 => 'l',
+        0x2c => 'z',
+        0x2d => 'x',
+        0x2e => 'c',
+        0x2f => 'v',
+        0x30 => 'b',
+        0x31 => 'n',
+        0x32 => 'm',
+        0x39 => ' ',
+        0x1c => '\n',
+        0x0e => '\u{8}',
+        0x0c => '-',
+        0x0d => '=',
+        0x27 => ';',
+        0x28 => '\'',
+        0x33 => ',',
+        0x34 => '.',
+        0x35 => '/',
+        _ => return None,
+    };
+
+    Some(c)
+}

--- a/hobby_os/kernel/src/main.rs
+++ b/hobby_os/kernel/src/main.rs
@@ -1,0 +1,30 @@
+#![no_std]
+#![no_main]
+
+mod keyboard;
+mod shell;
+mod vga;
+
+use core::panic::PanicInfo;
+
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    vga::init();
+    shell::banner();
+    shell::repl();
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    vga::clear_screen();
+    vga::print_line("Kernel panic");
+
+    if let Some(msg) = info.message() {
+        vga::print_line("Reason:");
+        vga::print_fmt(*msg);
+    }
+
+    loop {
+        x86_64::instructions::hlt();
+    }
+}

--- a/hobby_os/kernel/src/main.rs
+++ b/hobby_os/kernel/src/main.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 mod keyboard;
+mod serial;
 mod shell;
 mod vga;
 
@@ -9,6 +10,7 @@ use core::panic::PanicInfo;
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    serial::init();
     vga::init();
     shell::banner();
     shell::repl();

--- a/hobby_os/kernel/src/serial.rs
+++ b/hobby_os/kernel/src/serial.rs
@@ -1,0 +1,66 @@
+use x86_64::instructions::port::Port;
+
+const COM1_BASE: u16 = 0x3F8;
+
+pub fn init() {
+    unsafe {
+        let mut interrupt_enable = Port::<u8>::new(COM1_BASE + 1);
+        let mut line_control = Port::<u8>::new(COM1_BASE + 3);
+        let mut divisor_lsb = Port::<u8>::new(COM1_BASE + 0);
+        let mut divisor_msb = Port::<u8>::new(COM1_BASE + 1);
+        let mut fifo_control = Port::<u8>::new(COM1_BASE + 2);
+        let mut modem_control = Port::<u8>::new(COM1_BASE + 4);
+
+        interrupt_enable.write(0x00);
+        line_control.write(0x80);
+        divisor_lsb.write(0x03);
+        divisor_msb.write(0x00);
+        line_control.write(0x03);
+        fifo_control.write(0xC7);
+        modem_control.write(0x0B);
+    }
+}
+
+pub fn print(text: &str) {
+    for b in text.bytes() {
+        write_byte(b);
+    }
+}
+
+pub fn print_line(text: &str) {
+    print(text);
+    print("\n");
+}
+
+pub fn try_read_char() -> Option<char> {
+    let has_data = unsafe {
+        let mut line_status = Port::<u8>::new(COM1_BASE + 5);
+        line_status.read() & 0x01 != 0
+    };
+
+    if !has_data {
+        return None;
+    }
+
+    let byte = unsafe {
+        let mut data_port = Port::<u8>::new(COM1_BASE);
+        data_port.read()
+    };
+
+    match byte {
+        b'\r' => Some('\n'),
+        0x08 | 0x7f => Some('\u{8}'),
+        0x20..=0x7e | b'\n' => Some(byte as char),
+        _ => None,
+    }
+}
+
+fn write_byte(byte: u8) {
+    unsafe {
+        let mut line_status = Port::<u8>::new(COM1_BASE + 5);
+        while line_status.read() & 0x20 == 0 {}
+
+        let mut data_port = Port::<u8>::new(COM1_BASE);
+        data_port.write(byte);
+    }
+}

--- a/hobby_os/kernel/src/shell.rs
+++ b/hobby_os/kernel/src/shell.rs
@@ -1,0 +1,213 @@
+use crate::{keyboard, vga};
+
+const MAX_INPUT: usize = 128;
+
+type UtilityFn = fn(&[&str]);
+
+struct Utility {
+    name: &'static str,
+    help: &'static str,
+    runner: UtilityFn,
+}
+
+static UTILITIES: &[Utility] = &[
+    Utility {
+        name: "echo",
+        help: "echo [text] - prints text",
+        runner: util_echo,
+    },
+    Utility {
+        name: "sum",
+        help: "sum a b - adds two integers",
+        runner: util_sum,
+    },
+    Utility {
+        name: "about",
+        help: "about - project info",
+        runner: util_about,
+    },
+];
+
+pub fn banner() {
+    vga::print_line("AruviX HobbyOS (Rust)");
+    vga::print_line("Type 'help' for commands.\n");
+}
+
+pub fn repl() -> ! {
+    let mut input = [0u8; MAX_INPUT];
+
+    loop {
+        vga::print("$ ");
+        let len = read_line(&mut input);
+        let line = core::str::from_utf8(&input[..len]).unwrap_or_default();
+        handle_command(line);
+    }
+}
+
+fn read_line(buf: &mut [u8; MAX_INPUT]) -> usize {
+    let mut len = 0;
+
+    loop {
+        let c = keyboard::read_char_blocking();
+
+        match c {
+            '\n' => {
+                vga::print("\n");
+                return len;
+            }
+            '\u{8}' => {
+                if len > 0 {
+                    len -= 1;
+                    vga::print("\u{8} \u{8}");
+                }
+            }
+            ch => {
+                if len < MAX_INPUT - 1 {
+                    buf[len] = ch as u8;
+                    len += 1;
+                    let mut tmp = [0u8; 4];
+                    let rendered = ch.encode_utf8(&mut tmp);
+                    vga::print(rendered);
+                }
+            }
+        }
+    }
+}
+
+fn handle_command(line: &str) {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let mut parts = trimmed.split_whitespace();
+    let Some(cmd) = parts.next() else {
+        return;
+    };
+    let args: heapless::Vec<&str, 16> = parts.collect();
+
+    match cmd {
+        "help" => {
+            vga::print_line("Builtins: help, ls, run <utility>, clear");
+            vga::print_line("Utilities:");
+            for util in UTILITIES {
+                vga::print("  - ");
+                vga::print_line(util.help);
+            }
+        }
+        "ls" => {
+            for util in UTILITIES {
+                vga::print_line(util.name);
+            }
+        }
+        "run" => {
+            if args.is_empty() {
+                vga::print_line("usage: run <utility> [args]");
+                return;
+            }
+
+            let target = args[0];
+            let rest = &args[1..];
+            if let Some(util) = UTILITIES.iter().find(|u| u.name == target) {
+                (util.runner)(rest);
+            } else {
+                vga::print_line("utility not found");
+            }
+        }
+        "clear" => vga::clear_screen(),
+        _ => vga::print_line("unknown command"),
+    }
+}
+
+fn util_echo(args: &[&str]) {
+    if args.is_empty() {
+        vga::print_line("");
+        return;
+    }
+
+    for (i, arg) in args.iter().enumerate() {
+        if i > 0 {
+            vga::print(" ");
+        }
+        vga::print(arg);
+    }
+    vga::print("\n");
+}
+
+fn util_sum(args: &[&str]) {
+    if args.len() != 2 {
+        vga::print_line("usage: run sum <a> <b>");
+        return;
+    }
+
+    let a = parse_i32(args[0]);
+    let b = parse_i32(args[1]);
+
+    match (a, b) {
+        (Some(x), Some(y)) => {
+            let result = x + y;
+            vga::print_line("result:");
+            print_i32(result);
+            vga::print("\n");
+        }
+        _ => vga::print_line("sum expects integer inputs"),
+    }
+}
+
+fn util_about(_: &[&str]) {
+    vga::print_line("Simple command shell for a hobby OS.");
+    vga::print_line("Use this as the base to load utilities compiled from C/Rust.");
+}
+
+fn parse_i32(text: &str) -> Option<i32> {
+    let bytes = text.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let (start, sign) = if bytes[0] == b'-' { (1, -1i32) } else { (0, 1i32) };
+    if start == bytes.len() {
+        return None;
+    }
+
+    let mut acc: i32 = 0;
+    for &b in &bytes[start..] {
+        if !b.is_ascii_digit() {
+            return None;
+        }
+        acc = acc.checked_mul(10)?;
+        acc = acc.checked_add((b - b'0') as i32)?;
+    }
+
+    acc.checked_mul(sign)
+}
+
+fn print_i32(value: i32) {
+    let mut buf = [0u8; 12];
+    let mut idx = buf.len();
+    let mut n = value;
+    let negative = n < 0;
+
+    if n == 0 {
+        vga::print("0");
+        return;
+    }
+
+    if negative {
+        n = -n;
+    }
+
+    while n > 0 {
+        idx -= 1;
+        buf[idx] = b'0' + (n % 10) as u8;
+        n /= 10;
+    }
+
+    if negative {
+        idx -= 1;
+        buf[idx] = b'-';
+    }
+
+    let s = core::str::from_utf8(&buf[idx..]).unwrap_or("?");
+    vga::print(s);
+}

--- a/hobby_os/kernel/src/shell.rs
+++ b/hobby_os/kernel/src/shell.rs
@@ -1,4 +1,4 @@
-use crate::{keyboard, vga};
+use crate::{keyboard, serial, vga};
 
 const MAX_INPUT: usize = 128;
 
@@ -48,7 +48,10 @@ fn read_line(buf: &mut [u8; MAX_INPUT]) -> usize {
     let mut len = 0;
 
     loop {
-        let c = keyboard::read_char_blocking();
+        let Some(c) = serial::try_read_char().or_else(keyboard::try_read_char) else {
+            x86_64::instructions::hlt();
+            continue;
+        };
 
         match c {
             '\n' => {

--- a/hobby_os/kernel/src/vga.rs
+++ b/hobby_os/kernel/src/vga.rs
@@ -1,3 +1,4 @@
+use crate::serial;
 use core::fmt;
 use lazy_static::lazy_static;
 use spin::Mutex;
@@ -141,6 +142,7 @@ pub fn clear_screen() {
 pub fn print(text: &str) {
     use core::fmt::Write;
     let _ = WRITER.lock().write_str(text);
+    serial::print(text);
 }
 
 pub fn print_line(text: &str) {

--- a/hobby_os/kernel/src/vga.rs
+++ b/hobby_os/kernel/src/vga.rs
@@ -1,0 +1,155 @@
+use core::fmt;
+use lazy_static::lazy_static;
+use spin::Mutex;
+use volatile::Volatile;
+
+const BUFFER_HEIGHT: usize = 25;
+const BUFFER_WIDTH: usize = 80;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy)]
+#[repr(u8)]
+pub enum Color {
+    Black = 0,
+    Blue = 1,
+    Green = 2,
+    Cyan = 3,
+    Red = 4,
+    Magenta = 5,
+    Brown = 6,
+    LightGray = 7,
+    DarkGray = 8,
+    LightBlue = 9,
+    LightGreen = 10,
+    LightCyan = 11,
+    LightRed = 12,
+    Pink = 13,
+    Yellow = 14,
+    White = 15,
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+struct ColorCode(u8);
+
+impl ColorCode {
+    fn new(foreground: Color, background: Color) -> Self {
+        Self((background as u8) << 4 | (foreground as u8))
+    }
+}
+
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct ScreenChar {
+    ascii_character: u8,
+    color_code: ColorCode,
+}
+
+#[repr(transparent)]
+struct Buffer {
+    chars: [[Volatile<ScreenChar>; BUFFER_WIDTH]; BUFFER_HEIGHT],
+}
+
+pub struct Writer {
+    column_position: usize,
+    color_code: ColorCode,
+    buffer: &'static mut Buffer,
+}
+
+impl Writer {
+    fn write_byte(&mut self, byte: u8) {
+        match byte {
+            b'\n' => self.new_line(),
+            byte => {
+                if self.column_position >= BUFFER_WIDTH {
+                    self.new_line();
+                }
+
+                let row = BUFFER_HEIGHT - 1;
+                let col = self.column_position;
+                self.buffer.chars[row][col].write(ScreenChar {
+                    ascii_character: byte,
+                    color_code: self.color_code,
+                });
+                self.column_position += 1;
+            }
+        }
+    }
+
+    fn new_line(&mut self) {
+        for row in 1..BUFFER_HEIGHT {
+            for col in 0..BUFFER_WIDTH {
+                let character = self.buffer.chars[row][col].read();
+                self.buffer.chars[row - 1][col].write(character);
+            }
+        }
+        self.clear_row(BUFFER_HEIGHT - 1);
+        self.column_position = 0;
+    }
+
+    fn clear_row(&mut self, row: usize) {
+        let blank = ScreenChar {
+            ascii_character: b' ',
+            color_code: self.color_code,
+        };
+
+        for col in 0..BUFFER_WIDTH {
+            self.buffer.chars[row][col].write(blank);
+        }
+    }
+
+    fn clear_screen_internal(&mut self) {
+        for row in 0..BUFFER_HEIGHT {
+            self.clear_row(row);
+        }
+        self.column_position = 0;
+    }
+
+    fn write_string(&mut self, text: &str) {
+        for byte in text.bytes() {
+            match byte {
+                0x20..=0x7e | b'\n' => self.write_byte(byte),
+                _ => self.write_byte(0xfe),
+            }
+        }
+    }
+}
+
+impl fmt::Write for Writer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.write_string(s);
+        Ok(())
+    }
+}
+
+lazy_static! {
+    static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
+        column_position: 0,
+        color_code: ColorCode::new(Color::LightGreen, Color::Black),
+        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) },
+    });
+}
+
+pub fn init() {
+    clear_screen();
+}
+
+pub fn clear_screen() {
+    WRITER.lock().clear_screen_internal();
+}
+
+pub fn print(text: &str) {
+    use core::fmt::Write;
+    let _ = WRITER.lock().write_str(text);
+}
+
+pub fn print_line(text: &str) {
+    print(text);
+    print("\n");
+}
+
+pub fn print_fmt(args: fmt::Arguments<'_>) {
+    use core::fmt::Write;
+    let _ = WRITER.lock().write_fmt(args);
+    print("\n");
+}

--- a/hobby_os/programs/asm/noop_util.s
+++ b/hobby_os/programs/asm/noop_util.s
@@ -1,0 +1,4 @@
+    .global _start
+_start:
+    nop
+    jmp _start

--- a/hobby_os/programs/c/hello_util.c
+++ b/hobby_os/programs/c/hello_util.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("hello_util from host-side test build");
+    return 0;
+}

--- a/hobby_os/programs/c/sum_util.c
+++ b/hobby_os/programs/c/sum_util.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "usage: sum_util <a> <b>\n");
+        return 1;
+    }
+
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    printf("%d\n", a + b);
+    return 0;
+}

--- a/hobby_os/scripts/create_vdi.sh
+++ b/hobby_os/scripts/create_vdi.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_PATH="${1:-}"
+VDI_PATH="${2:-hobby_os.vdi}"
+
+if [[ -z "${IMAGE_PATH}" ]]; then
+  echo "usage: create_vdi.sh <bootimage.bin> [output.vdi]" >&2
+  exit 2
+fi
+
+if [[ ! -f "${IMAGE_PATH}" ]]; then
+  echo "error: image not found: ${IMAGE_PATH}" >&2
+  exit 2
+fi
+
+if ! command -v VBoxManage >/dev/null 2>&1; then
+  echo "error: VBoxManage not found. Install VirtualBox first." >&2
+  exit 2
+fi
+
+VBoxManage convertfromraw "${IMAGE_PATH}" "${VDI_PATH}" --format VDI
+
+echo "Created ${VDI_PATH}"

--- a/hobby_os/scripts/test_terminal.py
+++ b/hobby_os/scripts/test_terminal.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+import os
+import selectors
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+IMAGE = ROOT / "kernel/target/x86_64-unknown-none/debug/bootimage-aruvix_hobby_os.bin"
+
+
+def main() -> int:
+    if not shutil.which("qemu-system-x86_64"):
+        print("[SKIP] qemu-system-x86_64 not found")
+        return 0
+
+    if not IMAGE.exists():
+        print(f"[FAIL] boot image not found: {IMAGE}")
+        return 1
+
+    cmd = [
+        "qemu-system-x86_64",
+        "-drive",
+        f"format=raw,file={IMAGE}",
+        "-nographic",
+        "-serial",
+        "stdio",
+        "-monitor",
+        "none",
+        "-display",
+        "none",
+        "-no-reboot",
+    ]
+
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=ROOT,
+        env={**os.environ, "LC_ALL": "C"},
+        bufsize=1,
+    )
+
+    sel = selectors.DefaultSelector()
+    assert proc.stdout is not None
+    sel.register(proc.stdout, selectors.EVENT_READ)
+
+    def write_line(line: str) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(line)
+        proc.stdin.flush()
+
+    output = ""
+    try:
+        time.sleep(2.0)
+        for line in [
+            "help\n",
+            "ls\n",
+            "run echo smoke_test\n",
+            "run sum 7 35\n",
+            "run noexist\n",
+        ]:
+            write_line(line)
+            time.sleep(0.4)
+
+        deadline = time.time() + 6.0
+        while time.time() < deadline:
+            events = sel.select(timeout=0.25)
+            for key, _ in events:
+                chunk = key.fileobj.read()  # line-buffered chunks
+                if not chunk:
+                    continue
+                output += chunk
+
+        required = [
+            "AruviX HobbyOS (Rust)",
+            "Builtins: help, ls, run <utility>, clear",
+            "echo",
+            "sum",
+            "about",
+            "smoke_test",
+            "result:",
+            "42",
+            "utility not found",
+        ]
+
+        missing = [item for item in required if item not in output]
+        if missing:
+            print(output)
+            print(f"[FAIL] missing expected output: {missing}")
+            return 1
+
+        print("[PASS] terminal smoke test passed")
+        return 0
+    finally:
+        proc.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hobby_os/tests/test_cases.md
+++ b/hobby_os/tests/test_cases.md
@@ -20,11 +20,24 @@ make test-terminal
 1. Compile sample C utilities.
 2. Assemble sample ASM utility object.
 3. Execute compiled `sum_util` and assert expected result (`42`).
+4. Bundle generated utilities into `out/program_bundle/` with a manifest.
 
 Run with:
 
 ```bash
 make test-programs
+make bundle-programs
+```
+
+## VirtualBox packaging check
+
+1. Ensure VirtualBox is installed (`VBoxManage` in PATH).
+2. Build image and convert to VDI.
+
+Run with:
+
+```bash
+make vdi
 ```
 
 ## End-to-end test

--- a/hobby_os/tests/test_cases.md
+++ b/hobby_os/tests/test_cases.md
@@ -1,0 +1,34 @@
+# Hobby OS Test Cases
+
+## Terminal smoke tests (automated via serial)
+
+1. Boot OS and check banner appears.
+2. Run `help` and confirm builtin help text.
+3. Run `ls` and confirm `echo`, `sum`, `about` are listed.
+4. Run `run echo smoke_test` and confirm argument echoing.
+5. Run `run sum 7 35` and confirm output includes `42`.
+6. Run `run noexist` and confirm graceful error (`utility not found`).
+
+Run with:
+
+```bash
+make test-terminal
+```
+
+## Program packaging tests
+
+1. Compile sample C utilities.
+2. Assemble sample ASM utility object.
+3. Execute compiled `sum_util` and assert expected result (`42`).
+
+Run with:
+
+```bash
+make test-programs
+```
+
+## End-to-end test
+
+```bash
+make test
+```

--- a/hobby_os/user_utils/src/echo.c
+++ b/hobby_os/user_utils/src/echo.c
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+// Example utility entrypoint style for future ABI integration.
+// For now these files document intended utility shape.
+int32_t util_echo(int argc, const char **argv) {
+    (void)argc;
+    (void)argv;
+    return 0;
+}

--- a/hobby_os/user_utils/src/sum.c
+++ b/hobby_os/user_utils/src/sum.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+int32_t util_sum(int32_t a, int32_t b) {
+    return a + b;
+}


### PR DESCRIPTION
### Motivation
- Provide a compact starter operating system scaffold that demonstrates the full cycle: boot, interactive shell, list utilities, and execute utilities, with a clear layout for incremental improvements. 
- Make it easy to iterate locally and run the OS in a VM by including build helpers and VirtualBox conversion guidance. 

### Description
- Add a new `hobby_os/` workspace containing `build/`, `docs/`, `kernel/`, and `user_utils/` with a documented folder structure and usage in `hobby_os/README.md`.
- Implement a minimal bare-metal Rust kernel (`kernel/src/main.rs`) with VGA text output (`vga.rs`), PS/2 keyboard input (`keyboard.rs`), and a panic handler.
- Implement a simple interactive shell (`kernel/src/shell.rs`) with built-ins `help`, `ls`, `run <utility> [args]`, and `clear`, plus a static utility registry with demo utilities `echo`, `sum`, and `about`.
- Add build helpers and configuration including `kernel/Cargo.toml`, `kernel/rust-toolchain.toml`, `.cargo/config.toml`, and `build/Makefile` to produce a bootable image and instructions to convert the raw image to a VirtualBox VDI, and include C utility skeletons and a `docs/roadmap.md` for next steps (ABI, loader, ELF support).

### Testing
- Attempted to run `cd hobby_os/kernel && cargo fmt` which failed due to rustup/toolchain network access errors in this environment. 
- No further automated tests (image build or `cargo bootimage`) were executed because toolchain/network access was unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a97369b10832ea6fb91510d412aa9)